### PR TITLE
update badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pantheon Edge Integrations Drupal SDK
 
-[![Unsupported](https://img.shields.io/badge/pantheon-unsupported-yellow?logo=pantheon&color=FFDC28)](https://github.com/topics/unsupported?q=org%3Apantheon-systems "Unsupported, e.g. a tool we are actively using internally and are making available, but do not promise to support") ![Packagist Version](https://img.shields.io/packagist/v/pantheon-systems/edge-integrations-drupal-sdk) ![MIT License](https://img.shields.io/github/license/pantheon-systems/edge-integrations-drupal-sdk)
+[![Unsupported](https://img.shields.io/badge/pantheon-unsupported-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#unsupported) ![Packagist Version](https://img.shields.io/packagist/v/pantheon-systems/edge-integrations-drupal-sdk) ![MIT License](https://img.shields.io/github/license/pantheon-systems/edge-integrations-drupal-sdk)
 
 Welcome to the Pantheon Edge Integrations Drupal SDK!
 


### PR DESCRIPTION
Now that https://pantheon.io/docs/oss-support-levels exists, our badges should point there.