### PR TITLE
Adds missing slashes to URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Edge Integrations start with the "edge" itself, the CDN layer that is the last s
 The [Pantheon Edge Integrations](https://github.com/pantheon-systems/pantheon-edge-integrations) global library allows developers to interact with the header data sent to and from the CDN. This is a low level interface that simplifies the process of communicating with and interpretting headers sent from the CDN. It's important to note that the Edge Integrations library is built as a generic, CMS-agnostic PHP package, and is used as the base of both the WordPress and the Drupal implementations.
 
 #### Smart Content CDN
-[Smart Content CDN](https:github.com/pantheon-systems/smart_content_cdn) uses interfaces provided by [Smart Content](https://www.drupal.org/project/smart_content) as well as the interactions with header data enabled by the Pantheon Edge Integrations library to handle the two-way communication between the CDN and the CMS to render personalized content by geolocation or interest.
+[Smart Content CDN](https://github.com/pantheon-systems/smart_content_cdn) uses interfaces provided by [Smart Content](https://www.drupal.org/project/smart_content) as well as the interactions with header data enabled by the Pantheon Edge Integrations library to handle the two-way communication between the CDN and the CMS to render personalized content by geolocation or interest.
 
 #### Smart Content Preview
 [Smart Content Preview](https://www.drupal.org/project/smart_content_preview) allows blocks created with Smart Content to be previewed and tested. In this case, this allows the site administrator to preview geolocation- or interest-based content on the front-end. This module is currently still in development.


### PR DESCRIPTION
When attempting to navigate to the URL it gives a 404 error to the link with a message:

```
 The 'pantheon-systems/edge-integrations-drupal-sdk' repository doesn't contain the 'github.com/pantheon-systems/smart_content_cdn' path in 'main'. 
```

Adding the slashes corrects that behavior and points to the correct repo.