### PR TITLE
Release 0.3.0-alpha1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "sort-packages": true
     },
     "require": {
-        "pantheon-systems/pantheon-edge-integrations": "^1.0"
+        "pantheon-systems/pantheon-edge-integrations": "^1.1"
     },
     "suggest": {
         "pantheon-systems/smart_content_cdn": "The Smart Content CDN module provides a way to interact with headers sent by Pantheon's AGCDN to personalize blocks of content using the Smart Content module."

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1683003002df7a356b8151ff2c3490d8",
+    "content-hash": "944f3e013cc566f9ce54dbf8235c1f1e",
     "packages": [
         {
             "name": "pantheon-systems/pantheon-edge-integrations",
-            "version": "1.0.1",
+            "version": "v1.1.0-alpha1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/pantheon-edge-integrations.git",
-                "reference": "4a6447a6d009ca8f6410390f4f0971ee7cd0de19"
+                "reference": "529b95b0759efe3dc80532d005ccc87a7c41abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/pantheon-edge-integrations/zipball/4a6447a6d009ca8f6410390f4f0971ee7cd0de19",
-                "reference": "4a6447a6d009ca8f6410390f4f0971ee7cd0de19",
+                "url": "https://api.github.com/repos/pantheon-systems/pantheon-edge-integrations/zipball/529b95b0759efe3dc80532d005ccc87a7c41abd1",
+                "reference": "529b95b0759efe3dc80532d005ccc87a7c41abd1",
                 "shasum": ""
             },
             "require-dev": {
@@ -40,9 +40,9 @@
             "description": "Helper class for content personalization.",
             "support": {
                 "issues": "https://github.com/pantheon-systems/pantheon-edge-integrations/issues",
-                "source": "https://github.com/pantheon-systems/pantheon-edge-integrations/tree/1.0.1"
+                "source": "https://github.com/pantheon-systems/pantheon-edge-integrations/tree/v1.1.0-alpha1"
             },
-            "time": "2022-02-24T17:14:59+00:00"
+            "time": "2022-06-01T21:29:18+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Because the `minimum-stability` is set to `dev` we can release a "set it and forget it" update to `pantheon-edge-integrations` to 1.1.x despite that package only being an alpha. 

I don't anticipate any changes between the alpha and the final of 0.3.0 for this repository, but leaving as alpha so that all packages can be updated at the same time and maintain consistency.